### PR TITLE
Fixed a compiler warning.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 % Compiler Options for rebar
-{erl_opts, [{parse_transform, lager_transform}, debug_info, {src_dirs, ["src"]}]}.
+{erl_opts, [{parse_transform, lager_transform}, debug_info, warnings_as_errors, {src_dirs, ["src"]}]}.
 
 % Dependencies
 {deps, [

--- a/src/gcm.erl
+++ b/src/gcm.erl
@@ -167,7 +167,7 @@ do_push(RegIds, Message, Key, ErrorFun) ->
     ApiKey = string:concat("key=", Key),
 
     try httpc:request(post, {?BASEURL, [{"Authorization", ApiKey}], "application/json", GCMRequest}, [], []) of
-        {ok, {{_, 200, _}, Headers, GCMResponse}} ->
+        {ok, {{_, 200, _}, _Headers, GCMResponse}} ->
             Json = jsx:decode(response_to_binary(GCMResponse)),
             handle_push_result(Json, RegIds, ErrorFun);
         {error, Reason} ->


### PR DESCRIPTION
Headers on src/gcm.erl line 170 was unused, prefixed with an _ and turned on warnings_as_errors
