### PR TITLE
Don't assume a 400 Bad Request was due to bad JSON

### DIFF
--- a/src/gcm.app.src
+++ b/src/gcm.app.src
@@ -1,6 +1,6 @@
 {application, gcm, [
     {description, "An Erlang client for Google Cloud Messaging (GCM)"},
-    {vsn, "1.0.0"},
+    {vsn, "1.0.1"},
     {registered, [gcm_sup]},
     {applications, [
         kernel,

--- a/src/gcm_api.erl
+++ b/src/gcm_api.erl
@@ -19,9 +19,9 @@ push(RegIds, Message, Key) ->
             Json = jsx:decode(response_to_binary(Body)),
             error_logger:info_msg("Result was: ~p~n", [Json]),
             {ok, result_from(Json)};
-        {ok, {{_, 400, _}, _, _}} ->
-	    error_logger:error_msg("Error in request. Reason was: json_error~n", []),
-            {error, json_error};
+        {ok, {{_, 400, _}, _, Body}} ->
+	    error_logger:error_msg("Error in request. Reason was: Bad Request - ~p~n", [Body]),
+            {error, Body};
         {ok, {{_, 401, _}, _, _}} ->
 	    error_logger:error_msg("Error in request. Reason was: authorization error~n", []),
             {error, auth_error};


### PR DESCRIPTION
e.g. makes a mistake like this clearer

```
22> gcm:push(foo, [], []).                                                                                                                                                           
=INFO REPORT==== 5-May-2015::16:59:58 ===
Sending message: [] to reg ids: [] retries: 3.
ok
23> 
=ERROR REPORT==== 5-May-2015::16:59:58 ===
Error in request. Reason was: Bad Request - "\"registration_ids\" field cannot be empty\n"
```